### PR TITLE
Bonding

### DIFF
--- a/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
+++ b/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
@@ -42,21 +42,20 @@ public class FlutterBluetoothSerialPlugin implements MethodCallHandler, RequestP
     private final Registrar registrar;
     private final MethodChannel methodChannel;
     private Result pendingResultForActivityResult = null;
-    
+
     // Permissions
     private static final int REQUEST_COARSE_LOCATION_PERMISSIONS = 1451;
     private static final int REQUEST_ENABLE_BLUETOOTH = 2137;
-    
+
     // General Bluetooth
     private BluetoothAdapter bluetoothAdapter;
     private BluetoothManager bluetoothManager;
-    
+
     // State
     private final BroadcastReceiver stateReceiver;
     private EventSink stateSink;
 
     // Pairing requests
-    private final int pairingRequestReceiverPriority = 123;
     private final BroadcastReceiver pairingRequestReceiver;
     private boolean isPairingRequestHandlerSet = false;
 

--- a/example/lib/BluetoothDeviceListEntry.dart
+++ b/example/lib/BluetoothDeviceListEntry.dart
@@ -13,7 +13,7 @@ class BluetoothDeviceListEntry extends ListTile {
     onLongPress: onLongPress,
     enabled: enabled,
     leading: Icon(Icons.devices), // @TODO . !BluetoothClass! class aware icon
-    title: Text(device.name),
+    title: Text(device.name ?? ''),
     subtitle: Text(device.address.toString()),
     trailing: Row(
       mainAxisSize: MainAxisSize.min,

--- a/example/lib/DiscoveryPage.dart
+++ b/example/lib/DiscoveryPage.dart
@@ -68,6 +68,43 @@ class _DiscoveryPage extends State<DiscoveryPage> {
       onTap: () {
         Navigator.of(context).pop(result.device);
       },
+      onLongPress: () async {
+        try {
+          print('Bonding with ${result.device.address}...');
+          bool bonded = await FlutterBluetoothSerial.instance.bondDeviceAtAddress(result.device.address, pin: "1234");
+          print('Bonding ${bonded ? 'succed' : 'failed'} with ${result.device.address}.');
+          setState(() {
+            results[results.indexOf(result)] = BluetoothDiscoveryResult(
+              device: BluetoothDevice(
+                name: result.device.name,
+                address: result.device.address,
+                type: result.device.type,
+                bondState: bonded ? BluetoothBondState.bonded : BluetoothBondState.none,
+              ), 
+              rssi: result.rssi
+            );
+          });
+        }
+        catch (ex) {
+          showDialog(
+            context: context,
+            builder: (BuildContext context) {
+              return AlertDialog(
+                title: const Text('Error occured while bonding'),
+                content: Text("${ex.toString()}"),
+                actions: <Widget>[
+                  new FlatButton(
+                    child: new Text("Close"),
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                    },
+                  ),
+                ],
+              );
+            },
+          );
+        }
+      },
     )).toList();
     return Scaffold(
       appBar: AppBar(

--- a/example/lib/DiscoveryPage.dart
+++ b/example/lib/DiscoveryPage.dart
@@ -84,7 +84,7 @@ class _DiscoveryPage extends State<DiscoveryPage> {
           setState(() {
             results[results.indexOf(result)] = BluetoothDiscoveryResult(
               device: BluetoothDevice(
-                name: result.device.name,
+                name: result.device.name ?? '',
                 address: result.device.address,
                 type: result.device.type,
                 bondState: bonded ? BluetoothBondState.bonded : BluetoothBondState.none,

--- a/example/lib/DiscoveryPage.dart
+++ b/example/lib/DiscoveryPage.dart
@@ -71,7 +71,7 @@ class _DiscoveryPage extends State<DiscoveryPage> {
       onLongPress: () async {
         try {
           print('Bonding with ${result.device.address}...');
-          bool bonded = await FlutterBluetoothSerial.instance.bondDeviceAtAddress(result.device.address, pin: "1234");
+          bool bonded = await FlutterBluetoothSerial.instance.bondDeviceAtAddress(result.device.address);
           print('Bonding ${bonded ? 'succed' : 'failed'} with ${result.device.address}.');
           setState(() {
             results[results.indexOf(result)] = BluetoothDiscoveryResult(

--- a/example/lib/DiscoveryPage.dart
+++ b/example/lib/DiscoveryPage.dart
@@ -70,9 +70,17 @@ class _DiscoveryPage extends State<DiscoveryPage> {
       },
       onLongPress: () async {
         try {
-          print('Bonding with ${result.device.address}...');
-          bool bonded = await FlutterBluetoothSerial.instance.bondDeviceAtAddress(result.device.address);
-          print('Bonding ${bonded ? 'succed' : 'failed'} with ${result.device.address}.');
+          bool bonded = false;
+          if (result.device.bonded) {
+            print('Unbonding from ${result.device.address}...');
+            await FlutterBluetoothSerial.instance.removeDeviceBondWithAddress(result.device.address);
+            print('Unbonding from ${result.device.address} has succed');
+          }
+          else {
+            print('Bonding with ${result.device.address}...');
+            bonded = await FlutterBluetoothSerial.instance.bondDeviceAtAddress(result.device.address);
+            print('Bonding with ${result.device.address} has ${bonded ? 'succed' : 'failed'}.');
+          }
           setState(() {
             results[results.indexOf(result)] = BluetoothDiscoveryResult(
               device: BluetoothDevice(

--- a/example/lib/MainPage.dart
+++ b/example/lib/MainPage.dart
@@ -20,6 +20,8 @@ class _MainPage extends State<MainPage> {
 
   BackgroundCollectingTask _collectingTask;
 
+  bool _autoAcceptPairingRequests = false;
+
   @override
   void initState() {
     super.initState();
@@ -37,6 +39,7 @@ class _MainPage extends State<MainPage> {
 
   @override
   void dispose() {
+    FlutterBluetoothSerial.instance.setPairingRequestHandler(null);
     _collectingTask?.dispose();
     super.dispose();
   }
@@ -84,6 +87,27 @@ class _MainPage extends State<MainPage> {
             Divider(),
             ListTile(
               title: const Text('Devices discovery and connection')
+            ),
+            SwitchListTile(
+              title: const Text('Auto-try specific pin when pairing'),
+              subtitle: const Text('Pin 1234'),
+              value: _autoAcceptPairingRequests,
+              onChanged: (bool value) {
+                setState(() {
+                  _autoAcceptPairingRequests = value;
+                });
+                if (value) {
+                  FlutterBluetoothSerial.instance.setPairingRequestHandler((BluetoothPairingRequest request) {
+                    print("Trying to auto-pair with Pin 1234");
+                    if (request.pairingVariant == PairingVariant.Pin) {
+                      return Future.value("1234");
+                    }
+                  });
+                }
+                else {
+                  FlutterBluetoothSerial.instance.setPairingRequestHandler(null);
+                }
+              },
             ),
             ListTile(
               title: RaisedButton(

--- a/lib/BluetoothPairingRequest.dart
+++ b/lib/BluetoothPairingRequest.dart
@@ -1,0 +1,83 @@
+part of flutter_bluetooth_serial;
+
+/// Enum-like class for all types of pairing variants.
+class PairingVariant {
+  final int underlyingValue;
+
+  const PairingVariant._(this.underlyingValue);
+
+  factory PairingVariant.fromUnderlyingValue(int value) {
+    switch (value) {
+      case 0: return PairingVariant.Pin;
+      case 1: return PairingVariant.Passkey;
+      case 2: return PairingVariant.PasskeyConfirmation;
+      case 3: return PairingVariant.Consent;
+      case 4: return PairingVariant.DisplayPasskey;
+      case 5: return PairingVariant.DisplayPin;
+      case 6: return PairingVariant.OOB;
+      case 7: return PairingVariant.Pin16Digits;
+      default:return PairingVariant.Error;
+    }
+  }
+  int toUnderlyingValue() => underlyingValue;
+
+  String toString() {
+    switch (underlyingValue) {
+      case 0: return 'PairingVariant.Pin';
+      case 1: return 'PairingVariant.Passkey';
+      case 2: return 'PairingVariant.PasskeyConfirmation';
+      case 3: return 'PairingVariant.Consent';
+      case 4: return 'PairingVariant.DisplayPasskey';
+      case 5: return 'PairingVariant.DisplayPin';
+      case 6: return 'PairingVariant.OOB';
+      case 7: return 'PairingVariant.Pin16Digits';
+      default:return 'PairingVariant.Error';
+    }
+  }
+
+  static const Error                = PairingVariant._(-1);
+  static const Pin                  = PairingVariant._(0);
+  static const Passkey              = PairingVariant._(1);
+  static const PasskeyConfirmation  = PairingVariant._(2);
+  static const Consent              = PairingVariant._(3);
+  static const DisplayPasskey       = PairingVariant._(4);
+  static const DisplayPin           = PairingVariant._(5);
+  static const OOB                  = PairingVariant._(6);
+  static const Pin16Digits          = PairingVariant._(7);
+
+  // operator ==(Object other) {
+  //   return other is PairingVariant && other.underlyingValue == this.underlyingValue;
+  // }
+
+  // @override
+  // int get hashCode => underlyingValue.hashCode;
+}
+
+/// Represents information about incoming pairing request
+class BluetoothPairingRequest {
+  /// MAC address of the device or identificator for platform system (if MAC addresses are prohibited).
+  final String address;
+
+  /// Variant of the pairing methods.
+  final PairingVariant pairingVariant;
+
+  /// Passkey for confirmation.
+  final int passkey;
+
+  /// Construct `BluetoothPairingRequest` with given values.
+  const BluetoothPairingRequest({
+    this.address, 
+    this.pairingVariant,
+    this.passkey,
+  });
+
+  /// Creates `BluetoothPairingRequest` from map.
+  /// Internally used to receive the object from platform code.
+  factory BluetoothPairingRequest.fromMap(Map map) {
+    return BluetoothPairingRequest(
+      address: map['address'],
+      pairingVariant: PairingVariant.fromUnderlyingValue(map['variant']),
+      passkey: map['passkey'],
+    );
+  }
+}

--- a/lib/FlutterBluetoothSerial.dart
+++ b/lib/FlutterBluetoothSerial.dart
@@ -54,6 +54,21 @@ class FlutterBluetoothSerial {
 
 
   /* Discovering and bonding devices */
+  /// Checks bond state for given address (might be from system cache).
+  Future<BluetoothBondState> getBondStateForAddress(String address) async {
+    return BluetoothBondState.fromUnderlyingValue(await _methodChannel.invokeMethod('getDeviceBondState', {"address": address}));
+  }
+
+  /// Starts bonding with device with given address. 
+  /// Returns true if bonded, false if canceled.
+  /// 
+  /// `pin` or `passkeyConfirm` could be used to automate the bonding process.
+  /// Note: `passkeyConfirm` will probably not work, since 3rd party apps cannot
+  /// get `BLUETOOTH_PRIVILEGED` permission (at least on newest Androids).
+  Future<bool> bondDeviceAtAddress(String address, {String pin, bool passkeyConfirm = false}) async {
+    return await _methodChannel.invokeMethod('bondDevice', {"address": address, "pin": pin, "passkeyConfirm": passkeyConfirm});
+  }
+
   /// Returns list of bonded devices.
   Future<List<BluetoothDevice>> getBondedDevices() async {
     final List list = await _methodChannel.invokeMethod('getBondedDevices');

--- a/lib/FlutterBluetoothSerial.dart
+++ b/lib/FlutterBluetoothSerial.dart
@@ -4,15 +4,26 @@ class FlutterBluetoothSerial {
   // Plugin
   static const String namespace = 'flutter_bluetooth_serial';
 
-  static final MethodChannel _methodChannel = const MethodChannel('$namespace/methods');
-  final StreamController<MethodCall> _methodStreamController = new StreamController.broadcast();
-  Stream<MethodCall> get _methodStream => _methodStreamController.stream;
-  FlutterBluetoothSerial._() {
-    _methodChannel.setMethodCallHandler((MethodCall call) { _methodStreamController.add(call); });
-  }
-
   static FlutterBluetoothSerial _instance = new FlutterBluetoothSerial._();
   static FlutterBluetoothSerial get instance => _instance;
+
+  static final MethodChannel _methodChannel = const MethodChannel('$namespace/methods');
+  
+  FlutterBluetoothSerial._() {
+    _methodChannel.setMethodCallHandler((MethodCall call) {
+      switch (call.method) {
+        case 'handlePairingRequest':
+          if (_pairingRequestHandler != null) {
+            return _pairingRequestHandler(BluetoothPairingRequest.fromMap(call.arguments));
+          }
+          break;
+
+        default:
+          throw 'unknown common code method - not implemented';
+          break;
+      }
+    });
+  }
 
 
 
@@ -59,14 +70,87 @@ class FlutterBluetoothSerial {
     return BluetoothBondState.fromUnderlyingValue(await _methodChannel.invokeMethod('getDeviceBondState', {"address": address}));
   }
 
-  /// Starts bonding with device with given address. 
+  /// Starts outgoing bonding (pairing) with device with given address. 
   /// Returns true if bonded, false if canceled.
   /// 
-  /// `pin` or `passkeyConfirm` could be used to automate the bonding process.
+  /// `pin` or `passkeyConfirm` could be used to automate the bonding process,
+  /// using provided pin or confirmation if necessary. Can be used only if no
+  /// pairing request handler is already registered.
+  /// 
   /// Note: `passkeyConfirm` will probably not work, since 3rd party apps cannot
   /// get `BLUETOOTH_PRIVILEGED` permission (at least on newest Androids).
-  Future<bool> bondDeviceAtAddress(String address, {String pin, bool passkeyConfirm = false}) async {
-    return await _methodChannel.invokeMethod('bondDevice', {"address": address, "pin": pin, "passkeyConfirm": passkeyConfirm});
+  Future<bool> bondDeviceAtAddress(String address, {String pin, bool passkeyConfirm}) async {
+    if (pin != null || passkeyConfirm != null) {
+      if (_pairingRequestHandler != null) {
+        throw "pairing request handler already registered";
+      }
+      setPairingRequestHandler((BluetoothPairingRequest request) async {
+        Future.delayed(Duration(seconds: 1), () {
+          setPairingRequestHandler(null);
+        });
+        if (pin != null) {
+          switch (request.pairingVariant) {
+            case PairingVariant.Pin:
+              return pin;
+            default:
+              // Other pairing variant requested, ignoring pin
+              break;
+          }
+        }
+        if (passkeyConfirm != null) {
+          switch (request.pairingVariant) {
+            case PairingVariant.Consent:
+            case PairingVariant.PasskeyConfirmation:
+              return passkeyConfirm;
+            default:
+              // Other pairing variant requested, ignoring confirming
+              break;
+          }
+        }
+        // Other pairing variant used, cannot automate
+      });
+    }
+    return await _methodChannel.invokeMethod('bondDevice', {"address": address});
+  }
+
+  // Function used as pairing request handler.
+  Function _pairingRequestHandler;
+
+  /// Allows listening and responsing for incoming pairing requests.
+  /// 
+  /// Various variants of pairing requests might require different returns:
+  /// * `PairingVariant.Pin` or `PairingVariant.Pin16Digits`
+  /// (prompt to enter a pin)
+  ///   - return string containing the pin for pairing
+  ///   - return `false` to reject.
+  /// * `BluetoothDevice.PasskeyConfirmation`
+  /// (user needs to confirm displayed passkey, no rewriting necessary)
+  ///   - return `true` to accept, `false` to reject.
+  ///   - there is `passkey` parameter available.
+  /// * `PairingVariant.Consent` 
+  /// (just prompt with device name to accept without any code or passkey)
+  ///   - return `true` to accept, `false` to reject.
+  /// 
+  /// If returned null, the request will be passed for manual pairing
+  /// using default Android Bluetooth settings pairing dialog.
+  /// 
+  /// Note: Accepting request variant of `PasskeyConfirmation` and `Consent`
+  /// will probably fail, because it require Android `setPairingConfirmation` 
+  /// which requires `BLUETOOTH_PRIVILEGED` permission that 3rd party apps 
+  /// cannot acquire (at least on newest Androids) due to security reasons.
+  /// 
+  /// Note: It is necessary to return from handler within 10 seconds, since
+  /// Android BroadcastReceiver can wait safely only up to that duration.
+  void setPairingRequestHandler(Future<dynamic> handler(BluetoothPairingRequest request)) {
+    if (handler == null) {
+      _pairingRequestHandler = null;
+      _methodChannel.invokeMethod('pairingRequestHandlingDisable');
+      return;
+    }
+    if (_pairingRequestHandler == null) {
+      _methodChannel.invokeMethod('pairingRequestHandlingEnable');
+    }
+    _pairingRequestHandler = handler;
   }
 
   /// Returns list of bonded devices.
@@ -96,7 +180,7 @@ class FlutterBluetoothSerial {
     
     subscription = _discoveryChannel.receiveBroadcastStream().listen(
       controller.add,
-      onError: controller.addError,
+      onError: controller.addError, 
       onDone: controller.close,
     );
 

--- a/lib/FlutterBluetoothSerial.dart
+++ b/lib/FlutterBluetoothSerial.dart
@@ -71,7 +71,7 @@ class FlutterBluetoothSerial {
   }
 
   /// Starts outgoing bonding (pairing) with device with given address. 
-  /// Returns true if bonded, false if canceled.
+  /// Returns true if bonded, false if canceled or failed gracefully.
   /// 
   /// `pin` or `passkeyConfirm` could be used to automate the bonding process,
   /// using provided pin or confirmation if necessary. Can be used only if no
@@ -112,6 +112,12 @@ class FlutterBluetoothSerial {
     }
     return await _methodChannel.invokeMethod('bondDevice', {"address": address});
   }
+
+  /// Removes bond with device with specified address.
+  /// Returns true if unbonded, false if canceled or failed gracefully.
+  /// 
+  /// Note: May not work at every Android device!
+  Future<bool> removeDeviceBondWithAddress(String address) async => await _methodChannel.invokeMethod('removeDeviceBond', {'address': address});
 
   // Function used as pairing request handler.
   Function _pairingRequestHandler;

--- a/lib/flutter_bluetooth_serial.dart
+++ b/lib/flutter_bluetooth_serial.dart
@@ -11,6 +11,7 @@ part './BluetoothState.dart';
 part './BluetoothBondState.dart';
 part './BluetoothDeviceType.dart';
 part './BluetoothDevice.dart';
+part './BluetoothPairingRequest.dart';
 part './BluetoothDiscoveryResult.dart';
 part './BluetoothConnection.dart';
 part './FlutterBluetoothSerial.dart';


### PR DESCRIPTION
Adding bonding functionality. Requested by @FWeissenb.

Features:
+ outgoing pairing request,
+ pairing automation (by pass-key confirmation and by preselected pin),
+ able to detect canceling (`false`) instead of throwing it as error.

To do:
- listening incoming pairing request (`setPairingRequestHandler`) **[work in progress]**
- make user able to check pass-key while pairing automation (instead of just `confirmPasskey` flag),
- remove possibility of memory leak.

Needs further consideration:
* confirmation of pairing key needs permission unavailable for 3rd party application (but should stay in the code :F),
* ...