### PR TITLE
Discoverability

### DIFF
--- a/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
+++ b/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
@@ -359,6 +359,19 @@ public class FlutterBluetoothSerialPlugin implements MethodCallHandler, RequestP
                 result.success(null);
                 break;
 
+            case "getDiscoverableTimeout": {
+                try {
+                    java.lang.reflect.Method method;
+                    method = bluetoothAdapter.getClass().getMethod("getDiscoverableTimeout");
+                    int value = (int) method.invoke(bluetoothAdapter);
+                    result.success(value);
+                }
+                catch (Exception ex) {
+                    result.error("bond_error", "error while unbonding", exceptionToString(ex));
+                }
+                break;
+            }
+
             case "requestDiscoverable": {
                 Intent intent = new Intent(BluetoothAdapter.ACTION_REQUEST_DISCOVERABLE);
 

--- a/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
+++ b/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
@@ -359,18 +359,9 @@ public class FlutterBluetoothSerialPlugin implements MethodCallHandler, RequestP
                 result.success(null);
                 break;
 
-            case "getDiscoverableTimeout": {
-                try {
-                    java.lang.reflect.Method method;
-                    method = bluetoothAdapter.getClass().getMethod("getDiscoverableTimeout");
-                    int value = (int) method.invoke(bluetoothAdapter);
-                    result.success(value);
-                }
-                catch (Exception ex) {
-                    result.error("bond_error", "error while unbonding", exceptionToString(ex));
-                }
+            case "isDiscoverable":
+                result.success(bluetoothAdapter.getScanMode() == BluetoothAdapter.SCAN_MODE_CONNECTABLE_DISCOVERABLE);
                 break;
-            }
 
             case "requestDiscoverable": {
                 Intent intent = new Intent(BluetoothAdapter.ACTION_REQUEST_DISCOVERABLE);

--- a/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
+++ b/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
@@ -34,22 +34,24 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener;
+import io.flutter.plugin.common.PluginRegistry.ActivityResultListener;
 
-public class FlutterBluetoothSerialPlugin implements MethodCallHandler, RequestPermissionsResultListener {
+public class FlutterBluetoothSerialPlugin implements MethodCallHandler, RequestPermissionsResultListener, ActivityResultListener {
     // Plugin
     private static final String TAG = "FlutterBluePlugin";
     private static final String PLUGIN_NAMESPACE = "flutter_bluetooth_serial";
     private final Registrar registrar;
     private Result pendingResultForActivityResult = null;
-    
-    // Permissions
+
+    // Permissions and request constants
     private static final int REQUEST_COARSE_LOCATION_PERMISSIONS = 1451;
-    private static final int REQUEST_ENABLE_BLUETOOTH = 2137;
-    
+    private static final int REQUEST_ENABLE_BLUETOOTH = 1337;
+    private static final int REQUEST_DISCOVERABLE_BLUETOOTH = 2137;
+
     // General Bluetooth
     private BluetoothAdapter bluetoothAdapter;
     private BluetoothManager bluetoothManager;
-    
+
     // State
     private final BroadcastReceiver stateReceiver;
     private EventSink stateSink;
@@ -73,6 +75,7 @@ public class FlutterBluetoothSerialPlugin implements MethodCallHandler, RequestP
     public static void registerWith(Registrar registrar) {
         final FlutterBluetoothSerialPlugin instance = new FlutterBluetoothSerialPlugin(registrar);
         registrar.addRequestPermissionsResultListener(instance);
+        registrar.addActivityResultListener(instance);
     }
 
     /// Constructs the plugin instance
@@ -255,6 +258,7 @@ public class FlutterBluetoothSerialPlugin implements MethodCallHandler, RequestP
 
             case "requestEnable":
                 if (!bluetoothAdapter.isEnabled()) {
+                    pendingResultForActivityResult = result;
                     Intent intent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
                     ActivityCompat.startActivityForResult(registrar.activity(), intent, REQUEST_ENABLE_BLUETOOTH, null);
                 }
@@ -354,6 +358,25 @@ public class FlutterBluetoothSerialPlugin implements MethodCallHandler, RequestP
                 
                 result.success(null);
                 break;
+
+            case "requestDiscoverable": {
+                Intent intent = new Intent(BluetoothAdapter.ACTION_REQUEST_DISCOVERABLE);
+
+                if (call.hasArgument("duration")) {
+                    try {
+                        int duration = (int) call.argument("duration");
+                        intent.putExtra(BluetoothAdapter.EXTRA_DISCOVERABLE_DURATION, duration);
+                    }
+                    catch (ClassCastException ex) {
+                        result.error("invalid_argument", "'duration' argument is required to be integer", null);
+                        break;
+                    }
+                }
+
+                pendingResultForActivityResult = result;
+                ActivityCompat.startActivityForResult(registrar.activity(), intent, REQUEST_DISCOVERABLE_BLUETOOTH, null);
+                break;
+            }
 
             ////////////////////////////////////////////////////////////////////////////////
             /* Connecting and connection */
@@ -517,21 +540,20 @@ public class FlutterBluetoothSerialPlugin implements MethodCallHandler, RequestP
         return false;
     }
 
-    // @TODO ? Registrar addActivityResultListener(ActivityResultListener listener);
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    @Override
+    public boolean onActivityResult(int requestCode, int resultCode, Intent data) {
         switch (requestCode) {
             case REQUEST_ENABLE_BLUETOOTH:
-                if (resultCode == 0) { // @TODO - use underlying value of `Activity.RESULT_CANCELED` since we tend to use `androidx` in where I could find the value.
-                    pendingResultForActivityResult.success(false);
-                }
-                else {
-                    pendingResultForActivityResult.success(true);
-                }
-                break;
+                // @TODO - used underlying value of `Activity.RESULT_CANCELED` since we tend to use `androidx` in which I were not able to find the constant.
+                pendingResultForActivityResult.success(resultCode == 0 ? false : true);
+                return true;
+
+            case REQUEST_DISCOVERABLE_BLUETOOTH:
+                pendingResultForActivityResult.success(resultCode == 0 ? -1 : resultCode);
+                return true;
 
             default:
-                // Ignore.
-                break;
+                return false;
         }
     }
 

--- a/example/lib/MainPage.dart
+++ b/example/lib/MainPage.dart
@@ -121,7 +121,13 @@ class _MainPage extends State<MainPage> {
                         _discoverableTimeoutSecondsLeft = timeout;
                         _discoverableTimeoutTimer = Timer.periodic(Duration(seconds: 1), (Timer timer) {
                           setState(() {
-                            if (_discoverableTimeoutSecondsLeft <= 0) {
+                            if (_discoverableTimeoutSecondsLeft < 0) {
+                              FlutterBluetoothSerial.instance.isDiscoverable.then((isDiscoverable) {
+                                if (isDiscoverable) {
+                                  print("Discoverable after timeout... might be infinity timeout :F");
+                                  _discoverableTimeoutSecondsLeft += 1;
+                                }
+                              });
                               timer.cancel();
                               _discoverableTimeoutSecondsLeft = 0;
                             }

--- a/example/lib/MainPage.dart
+++ b/example/lib/MainPage.dart
@@ -80,6 +80,32 @@ class _MainPage extends State<MainPage> {
                 },
               ),
             ),
+            ListTile(
+              title: Text("Discoverable"),
+              subtitle: const Text("PsychoX-Luna"),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.edit),
+                    onPressed: null,
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.refresh),
+                    onPressed: () async {
+                      print('Discoverable requested');
+                      final int timeout = await FlutterBluetoothSerial.instance.requestDiscoverable(60);
+                      if (timeout < 0) {
+                        print('Discoverable mode denied');
+                      }
+                      else {
+                        print('Discoverable mode acquired for $timeout seconds');
+                      }
+                    },
+                  )
+                ]
+              )
+            ),
 
             Divider(),
             ListTile(

--- a/example/lib/MainPage.dart
+++ b/example/lib/MainPage.dart
@@ -92,7 +92,7 @@ class _MainPage extends State<MainPage> {
               ),
             ),
             ListTile(
-              title: _discoverableTimeoutSecondsLeft == 0 ? const Text("Discoverable") : Text("Discoverable for $_discoverableTimeoutSecondsLeft seconds"),
+              title: _discoverableTimeoutSecondsLeft == 0 ? const Text("Discoverable") : Text("Discoverable for ${_discoverableTimeoutSecondsLeft}s"),
               subtitle: const Text("PsychoX-Luna"),
               trailing: Row(
                 mainAxisSize: MainAxisSize.min,

--- a/example/lib/MainPage.dart
+++ b/example/lib/MainPage.dart
@@ -97,6 +97,10 @@ class _MainPage extends State<MainPage> {
               trailing: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
+                  Checkbox(
+                    value: _discoverableTimeoutSecondsLeft != 0,
+                    onChanged: null,
+                  ),
                   IconButton(
                     icon: const Icon(Icons.edit),
                     onPressed: null,

--- a/lib/FlutterBluetoothSerial.dart
+++ b/lib/FlutterBluetoothSerial.dart
@@ -89,7 +89,10 @@ class FlutterBluetoothSerial {
   Future<void> cancelDiscovery() async => await _methodChannel.invokeMethod('cancelDiscovery');
 
   // @TODO . add `discoverableName` (get/set)
-  // @TODO . add `discoverableTimeout` (get)
+
+  /// Timeout in seconds left in discoverable mode. Negative values means 
+  /// out of discoverable mode or error (such as adapter disabled).
+  Future<int> get discoverableTimeout => _methodChannel.invokeMethod("getDiscoverableTimeout");
 
   /// Asks for discoverable mode (probably always prompt for user interaction in fact).
   /// Returns number of seconds acquired or zero if canceled or failed gracefully.

--- a/lib/FlutterBluetoothSerial.dart
+++ b/lib/FlutterBluetoothSerial.dart
@@ -48,9 +48,6 @@ class FlutterBluetoothSerial {
   /// Opens the Bluetooth platform system settings.
   Future<void> openSettings() async => await _methodChannel.invokeMethod('openSettings');
 
-  // @TODO . add `discoverableName` (get/set)
-  // @TODO . add `requestDiscoverable`
-
 
 
   /* Discovering and bonding devices */
@@ -90,6 +87,16 @@ class FlutterBluetoothSerial {
 
   /// Cancels the discovery
   Future<void> cancelDiscovery() async => await _methodChannel.invokeMethod('cancelDiscovery');
+
+  // @TODO . add `discoverableName` (get/set)
+  // @TODO . add `discoverableTimeout` (get)
+
+  /// Asks for discoverable mode (probably always prompt for user interaction in fact).
+  /// Returns number of seconds acquired or zero if canceled or failed gracefully.
+  /// 
+  /// Duration might be capped to 120, 300 or 3600 seconds on some devices.
+  Future<int> requestDiscoverable(int durationInSeconds) async => await _methodChannel.invokeMethod("requestDiscoverable", {"duration": durationInSeconds});
+
 
 
   /* Connecting and connection */

--- a/lib/FlutterBluetoothSerial.dart
+++ b/lib/FlutterBluetoothSerial.dart
@@ -90,9 +90,8 @@ class FlutterBluetoothSerial {
 
   // @TODO . add `discoverableName` (get/set)
 
-  /// Timeout in seconds left in discoverable mode. Negative values means 
-  /// out of discoverable mode or error (such as adapter disabled).
-  Future<int> get discoverableTimeout => _methodChannel.invokeMethod("getDiscoverableTimeout");
+  /// Describes is the local device in discoverable mode.
+  Future<bool> get isDiscoverable => _methodChannel.invokeMethod("isDiscoverable");
 
   /// Asks for discoverable mode (probably always prompt for user interaction in fact).
   /// Returns number of seconds acquired or zero if canceled or failed gracefully.


### PR DESCRIPTION
Features:
+ discoverable mode requesting (with duration in seconds)
_~~+ getter for discoverable timeout left~~_
+ check is in discoverable mode,
+ example with countdown,

To do:
~~- More proper testing~~
+ allow change discoverable name

~~#### Needs further testing~~
~~My Huawei does not work properly with discoverable timeouts - it is discoverable all the time for some reason. I have no other devices at the moment and virtual machines are not working very well with the Bluetooth overall. In few days I will try to find another device to test it through...~~

~~If somebody has a few minutes, the test can be done for example by adding:~~
```Dart
// Not actual anymore.
```
~~Then after building, enable Bluetooth and click refresh icon to start discoverable mode. Then after few second click edit icon and check console output - the timeout should be less and less.~~