### PR TITLE
When actively disconnecting, judge the problem of state error.

### DIFF
--- a/android/src/main/java/io/github/edufolly/flutterbluetoothserial/BluetoothConnection.java
+++ b/android/src/main/java/io/github/edufolly/flutterbluetoothserial/BluetoothConnection.java
@@ -66,7 +66,7 @@ public abstract class BluetoothConnection
     
     /// Disconnects current session (ignore if not connected)
     public void disconnect() {
-        if (!isConnected()) {
+        if (isConnected()) {
             connectionThread.cancel();
             connectionThread = null;
         }


### PR DESCRIPTION
When actively disconnected, the unconnected state should be ignored.