### PR TITLE
Changed FutureOr<int> to FutureOr<dynamic> in getBondStateForAddress

### DIFF
--- a/lib/FlutterBluetoothSerial.dart
+++ b/lib/FlutterBluetoothSerial.dart
@@ -94,7 +94,7 @@ class FlutterBluetoothSerial {
   Future<BluetoothBondState> getBondStateForAddress(String address) async {
     return BluetoothBondState.fromUnderlyingValue(await (_methodChannel
             .invokeMethod('getDeviceBondState', {"address": address})
-        as FutureOr<int>));
+        as FutureOr<dynamic>));
   }
 
   /// Starts outgoing bonding (pairing) with device with given address.


### PR DESCRIPTION
As mentioned in the issue https://github.com/edufolly/flutter_bluetooth_serial/issues/139, the method `getBondStateForAddress` also throws this exception `type 'Future<dynamic>' is not a subtype of type 'FutureOr<int>' in type cast`.
This PR should complement the one from @hmney https://github.com/edufolly/flutter_bluetooth_serial/pull/140.