### PR TITLE
Fix platform specification in pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
 
 flutter:
   plugin:
-    platform:
+    platforms:
       android:
         package: io.github.edufolly.flutterbluetoothserial
         pluginClass: FlutterBluetoothSerialPlugin


### PR DESCRIPTION
Looks like an 's' was missed in platforms in the pubspec which would give the following error:


> Invalid plugin specification flutter_bluetooth_serial.
> Cannot find the `flutter.plugin.platforms` key in the `pubspec.yaml` file. An instruction to format the `pubspec.yaml` can be found here: https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin-platforms

