### PR TITLE
Fixing the missing devices when discovering for the first time. Fixes #151

### DIFF
--- a/lib/FlutterBluetoothSerial.dart
+++ b/lib/FlutterBluetoothSerial.dart
@@ -217,13 +217,20 @@ class FlutterBluetoothSerial {
       },
     );
 
-    await _methodChannel.invokeMethod('startDiscovery');
+    // If we are already discovering we cancel the discovery
+    // This is useful to prevent subscription to be done before we call startDiscovery
+    if((await isDiscovering) == true) {
+      await cancelDiscovery();
+    }
 
+    // We subscribe before calling startDiscovery to prevent loosing results
     subscription = _discoveryChannel.receiveBroadcastStream().listen(
-          controller.add,
-          onError: controller.addError,
-          onDone: controller.close,
-        );
+      controller.add,
+      onError: controller.addError,
+      onDone: controller.close,
+    );
+
+    await _methodChannel.invokeMethod('startDiscovery');
 
     yield* controller.stream
         .map((map) => BluetoothDiscoveryResult.fromMap(map));


### PR DESCRIPTION
The first time one call `startDiscovery()`, some results are lost and not sent through the stream returned by `startDiscovery`.
After investigation, it appeared to me this happens because the plugin calls `_methodChannel.invokeMethod('startDiscovery');` before listening to the EventChannel `_discoveryChannel`.
Therefore I switched the two code blocks. I also added something to prevent the following situation:
- We listen to the `_discoveryChannel` EventChannel.
- An past discovery finishes now which triggers the onDone method of the subsciption we just created
- We start a discovery.
- We return a closed empty stream which will never receive the result of the new discovery