### PR TITLE
chore: made _BluetoothStreamSink public

### DIFF
--- a/lib/BluetoothConnection.dart
+++ b/lib/BluetoothConnection.dart
@@ -33,7 +33,7 @@ class BluetoothConnection {
   /// Stream sink used to write to the remote Bluetooth device
   ///
   /// You should use some encoding to send string, for example `.add(ascii.encode('Hello!'))` or `.add(utf8.encode('Cześć!))`.
-  late _BluetoothStreamSink<Uint8List> output;
+  late BluetoothStreamSink<Uint8List> output;
 
   /// Describes is stream connected.
   bool get isConnected => output.isConnected;
@@ -52,7 +52,7 @@ class BluetoothConnection {
             );
 
     input = _readStreamController.stream;
-    output = _BluetoothStreamSink<Uint8List>(id);
+    output = BluetoothStreamSink<Uint8List>(id);
   }
 
   /// Returns connection to given address.
@@ -91,7 +91,7 @@ class BluetoothConnection {
 }
 
 /// Helper class for sending responses.
-class _BluetoothStreamSink<Uint8List> extends StreamSink<Uint8List> {
+class BluetoothStreamSink<Uint8List> extends StreamSink<Uint8List> {
   final int? _id;
 
   /// Describes is stream connected.
@@ -105,7 +105,7 @@ class _BluetoothStreamSink<Uint8List> extends StreamSink<Uint8List> {
   /// Exception to be returend from `done` Future, passed from `add` function or related.
   dynamic exception;
 
-  _BluetoothStreamSink(this._id) {
+  BluetoothStreamSink(this._id) {
     // `_doneFuture` must be initialized here because `close` must return the same future.
     // If it would be in `done` get body, it would result in creating new futures every call.
     _doneFuture = Future(() async {


### PR DESCRIPTION
This PR contains one small change - made `_BluetoothStreamSink` public.
Reason - tests. 
It was impossible to mock `BluetoothConnection.output` getter.