### PR TITLE
Android 12 'nearby devices' permission support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ rootProject.allprojects {
 }
 apply plugin: 'com.android.library'
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,7 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="io.github.edufolly.flutterbluetoothserial">
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation"/>
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30"/>
+    <uses-feature android:name="android.hardware.bluetooth" android:required="false"/>
 </manifest>

--- a/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
+++ b/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
@@ -16,6 +16,7 @@ import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
+import android.os.Build;
 import android.util.Log;
 import android.util.SparseArray;
 import android.os.AsyncTask;
@@ -49,7 +50,7 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
     private Result pendingResultForActivityResult = null;
 
     // Permissions and request constants
-    private static final int REQUEST_COARSE_LOCATION_PERMISSIONS = 1451;
+    private static final int REQUEST_BLUETOOTH_PERMISSIONS = 1451;
     private static final int REQUEST_ENABLE_BLUETOOTH = 1337;
     private static final int REQUEST_DISCOVERABLE_BLUETOOTH = 2137;
 
@@ -408,7 +409,7 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
         binding.addRequestPermissionsResultListener(
                 (requestCode, permissions, grantResults) -> {
                     switch (requestCode) {
-                        case REQUEST_COARSE_LOCATION_PERMISSIONS:
+                        case REQUEST_BLUETOOTH_PERMISSIONS:
                             pendingPermissionsEnsureCallbacks.onResult(grantResults[0] == PackageManager.PERMISSION_GRANTED);
                             pendingPermissionsEnsureCallbacks = null;
                             return true;
@@ -444,21 +445,35 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
     EnsurePermissionsCallback pendingPermissionsEnsureCallbacks = null;
 
     private void ensurePermissions(EnsurePermissionsCallback callbacks) {
-        if (
-                ContextCompat.checkSelfPermission(activity,
-                        Manifest.permission.ACCESS_COARSE_LOCATION)
-                        != PackageManager.PERMISSION_GRANTED
-                        || ContextCompat.checkSelfPermission(activity,
-                        Manifest.permission.ACCESS_FINE_LOCATION)
-                        != PackageManager.PERMISSION_GRANTED) {
-            ActivityCompat.requestPermissions(activity,
-                    new String[]{Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION},
-                    REQUEST_COARSE_LOCATION_PERMISSIONS);
+        ensurePermissions(callbacks, true);
+    }
 
-            pendingPermissionsEnsureCallbacks = callbacks;
+    private boolean hasPermission(String permission) {
+        return ContextCompat.checkSelfPermission(activity, permission) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    private void ensurePermissions(EnsurePermissionsCallback callbacks, boolean needPermissionOnOldVersions) {
+        String[] permissions;
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            permissions = new String[]{Manifest.permission.BLUETOOTH_CONNECT, Manifest.permission.BLUETOOTH_SCAN};
         } else {
-            callbacks.onResult(true);
+            if(!needPermissionOnOldVersions) {
+                callbacks.onResult(true);
+                return;
+            }
+            permissions = new String[]{Manifest.permission.ACCESS_FINE_LOCATION};
         }
+        for (String permission: permissions) {
+            if(!hasPermission(permission)) {
+                pendingPermissionsEnsureCallbacks = callbacks;
+                ActivityCompat.requestPermissions(activity,
+                        permissions,
+                        REQUEST_BLUETOOTH_PERMISSIONS);
+                return;
+            }
+        }
+
+        callbacks.onResult(true);
     }
 
 
@@ -547,6 +562,14 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
         }
     }
 
+    private String getBluetoothPermissionName() {
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            return "nearby devices";
+        } else {
+            return "location";
+        }
+    }
+
     private class FlutterBluetoothSerialMethodCallHandler implements MethodCallHandler {
         /// Provides access to the plugin methods
         @Override
@@ -580,9 +603,15 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
 
                 case "requestEnable":
                     if (!bluetoothAdapter.isEnabled()) {
-                        pendingResultForActivityResult = result;
-                        Intent intent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
-                        ActivityCompat.startActivityForResult(activity, intent, REQUEST_ENABLE_BLUETOOTH, null);
+                        ensurePermissions(granted -> {
+                            if(granted) {
+                                pendingResultForActivityResult = result;
+                                Intent intent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
+                                ActivityCompat.startActivityForResult(activity, intent, REQUEST_ENABLE_BLUETOOTH, null);
+                            } else {
+                                result.success(false);
+                            }
+                        }, false);
                     } else {
                         result.success(true);
                     }
@@ -590,8 +619,13 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
 
                 case "requestDisable":
                     if (bluetoothAdapter.isEnabled()) {
-                        bluetoothAdapter.disable();
-                        result.success(true);
+                        ensurePermissions(granted -> {
+                            if(granted) {
+                                bluetoothAdapter.disable();
+                            } else {
+                                result.success(false);
+                            }
+                        }, false);
                     } else {
                         result.success(false);
                     }
@@ -895,7 +929,7 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
                 case "getBondedDevices":
                     ensurePermissions(granted -> {
                         if (!granted) {
-                            result.error("no_permissions", "discovering other devices requires location access permission", null);
+                            result.error("no_permissions", "discovering other devices requires " + getBluetoothPermissionName() + " access permission", null);
                             return;
                         }
 
@@ -921,7 +955,7 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
                 case "startDiscovery":
                     ensurePermissions(granted -> {
                         if (!granted) {
-                            result.error("no_permissions", "discovering other devices requires location access permission", null);
+                            result.error("no_permissions", "discovering other devices requires "  + getBluetoothPermissionName() + " access permission", null);
                             return;
                         }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     lintOptions {
         disable 'InvalidPackage'
     }
@@ -23,7 +23,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.github.edufolly.flutterbluetoothserialexample"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -17,14 +17,15 @@
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name="io.flutter.embedding.android.FlutterActivity"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" android:exported="false"/>
+                <category android:name="android.intent.category.LAUNCHER" android:exported="false"/>
             </intent-filter>
         </activity>
         <meta-data android:name="flutterEmbedding" android:value="2" />

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -24,6 +24,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
In recent years, a global trend is to increase user privacy

And with the advancement of Android, it was no different here

In versions lower than Android 12, to use Bluetooth, you needed to request the user's location, a bold permission and for users it doesn't make sense to ask for location to use Bluetooth

Thanks to android 12 a new permission can be asked from users: "nearby devices", this pull request uses the [new android manifest permissions](https://developer.android.com/develop/connectivity/bluetooth/bt-permissions#declare-android12-or-higher) so you don't need to request location from users on more modern devices

| Before: | After: | 
|------|------|
| ![before](https://github.com/edufolly/flutter_bluetooth_serial/assets/23365486/b4f35b24-86b1-4300-9046-6233a57714d4) | ![after](https://github.com/edufolly/flutter_bluetooth_serial/assets/23365486/226c93f0-5b70-44e4-b0de-ec541303451f) |

Several pull requests have already been made in this project with the same functionality, but I decided to create my own for the following reasons:

- They ask on old devices for location permission to turn Bluetooth on and off, there is no need to ask if you don't go beyond that, in more modern versions, then yes, 'nearby devices' permission is needed to turn Bluetooth on/off
- The error message if it does not have permission is generic or unchanged, in this pull request it warns that the 'nearby devices' permission is missing if it is a new device and 'localization' if it is an older device
- Some created very long ifs or duplicated calls to methods that you don't need, such as `ActivityCompat.requestPermissions`

Hope this contribution helps!