### PR TITLE
feat: major upgrade to latest Flutter/Dart SDK and Android toolchain

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,37 +3,38 @@ version '1.0-SNAPSHOT'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:8.2.0'
     }
 }
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 apply plugin: 'com.android.library'
 android {
-    compileSdkVersion 30
+    namespace 'io.github.edufolly.flutterbluetoothserial'
+    compileSdkVersion 34
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         disable 'InvalidPackage'
     }
     dependencies {
-        implementation 'androidx.appcompat:appcompat:1.3.0'
+        implementation 'androidx.appcompat:appcompat:1.6.1'
     }
-    buildToolsVersion '30.0.3'
+    buildToolsVersion '34.0.0'
 }
 
 dependencies {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,7 +1,14 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.github.edufolly.flutterbluetoothserial">
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Bluetooth permissions for Android 11 and below -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+
+    <!-- Bluetooth permissions for Android 12 and above -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+
+    <!-- Location permissions for Bluetooth device discovery -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 </manifest>

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,29 +1,20 @@
-def localProperties = new Properties()
-def localPropertiesFile = rootProject.file('local.properties')
-if (localPropertiesFile.exists()) {
-    localPropertiesFile.withReader('UTF-8') { reader ->
-        localProperties.load(reader)
-    }
+plugins {
+    id "com.android.application"
+    id "dev.flutter.flutter-gradle-plugin"
 }
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
-}
-
-apply plugin: 'com.android.application'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    namespace 'io.github.edufolly.flutterbluetoothserialexample'
+    compileSdk 36
+    ndkVersion "27.0.12077973"
     lintOptions {
         disable 'InvalidPackage'
     }
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.github.edufolly.flutterbluetoothserialexample"
-        minSdkVersion 19
-        targetSdkVersion 30
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -35,7 +26,7 @@ android {
             signingConfig signingConfigs.debug
         }
     }
-    buildToolsVersion '30.0.3'
+    buildToolsVersion '34.0.0'
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -48,6 +39,6 @@ flutter {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.github.edufolly.flutterbluetoothserialexample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application
@@ -17,6 +16,7 @@
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name="io.flutter.embedding.android.FlutterActivity"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,11 +1,23 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.github.edufolly.flutterbluetoothserialexample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+
+    <!-- Bluetooth permissions for Android 11 and below -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+
+    <!-- Bluetooth permissions for Android 12 and above -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+
+    <!-- Location permissions for Bluetooth device discovery -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
@@ -17,6 +29,7 @@
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name="io.flutter.embedding.android.FlutterActivity"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,18 +1,18 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:8.2.0'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -24,6 +24,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register("clean", Delete) {
+    delete rootProject.layout.buildDirectory
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4096M
+android.enableR8=true

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,15 +1,24 @@
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
+
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.6.0" apply false
+}
+
 include ':app'
-
-def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
-
-def plugins = new Properties()
-def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
-if (pluginsFile.exists()) {
-    pluginsFile.withReader('UTF-8') { reader -> plugins.load(reader) }
-}
-
-plugins.each { name, path ->
-    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
-    include ":$name"
-    project(":$name").projectDir = pluginDirectory
-}

--- a/example/ios/Flutter/ephemeral/flutter_lldb_helper.py
+++ b/example/ios/Flutter/ephemeral/flutter_lldb_helper.py
@@ -1,0 +1,32 @@
+#
+# Generated file, do not edit.
+#
+
+import lldb
+
+def handle_new_rx_page(frame: lldb.SBFrame, bp_loc, extra_args, intern_dict):
+    """Intercept NOTIFY_DEBUGGER_ABOUT_RX_PAGES and touch the pages."""
+    base = frame.register["x0"].GetValueAsAddress()
+    page_len = frame.register["x1"].GetValueAsUnsigned()
+
+    # Note: NOTIFY_DEBUGGER_ABOUT_RX_PAGES will check contents of the
+    # first page to see if handled it correctly. This makes diagnosing
+    # misconfiguration (e.g. missing breakpoint) easier.
+    data = bytearray(page_len)
+    data[0:8] = b'IHELPED!'
+
+    error = lldb.SBError()
+    frame.GetThread().GetProcess().WriteMemory(base, data, error)
+    if not error.Success():
+        print(f'Failed to write into {base}[+{page_len}]', error)
+        return
+
+def __lldb_init_module(debugger: lldb.SBDebugger, _):
+    target = debugger.GetDummyTarget()
+    # Caveat: must use BreakpointCreateByRegEx here and not
+    # BreakpointCreateByName. For some reasons callback function does not
+    # get carried over from dummy target for the later.
+    bp = target.BreakpointCreateByRegex("^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$")
+    bp.SetScriptCallbackFunction('{}.handle_new_rx_page'.format(__name__))
+    bp.SetAutoContinue(True)
+    print("-- LLDB integration loaded --")

--- a/example/ios/Flutter/ephemeral/flutter_lldbinit
+++ b/example/ios/Flutter/ephemeral/flutter_lldbinit
@@ -1,0 +1,5 @@
+#
+# Generated file, do not edit.
+#
+
+command script import --relative-to-command-file flutter_lldb_helper.py

--- a/example/lib/helpers/LineChart.dart
+++ b/example/lib/helpers/LineChart.dart
@@ -162,9 +162,9 @@ class LineChart extends StatelessWidget {
           values: values,
           valuesLabels: valuesLabels,
           horizontalLabelsTextStyle:
-              horizontalLabelsTextStyle ?? Theme.of(context).textTheme.caption,
+              horizontalLabelsTextStyle ?? Theme.of(context).textTheme.bodySmall,
           verticalLabelsTextStyle:
-              verticalLabelsTextStyle ?? Theme.of(context).textTheme.caption,
+              verticalLabelsTextStyle ?? Theme.of(context).textTheme.bodySmall,
           horizontalLinesPaint: horizontalLinesPaint,
           verticalLinesPaint: verticalLinesPaint,
           additionalMinimalHorizontalLabelsInterval:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,19 +1,18 @@
 name: flutter_bluetooth_serial_example
-version: 0.4.0
+version: 1.0.0
 description: Demonstrates how to use the `flutter_bluetooth_serial` plugin.
-authors:
-  - Patryk Ludwikowski <patryk.ludwikowski.7@gmail.com>
 homepage: https://github.com/edufolly/flutter_bluetooth_serial/tree/master/example/
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
 
-  scoped_model: ^2.0.0-nullsafety.0
-  cupertino_icons: ^1.0.3
+  scoped_model: ^2.0.0
+  cupertino_icons: ^1.0.8
+  permission_handler: ^11.3.1
 
 dev_dependencies:
   flutter_test:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,19 +1,17 @@
 name: flutter_bluetooth_serial_example
-version: 0.4.0
+version: 1.0.0
 description: Demonstrates how to use the `flutter_bluetooth_serial` plugin.
-authors:
-  - Patryk Ludwikowski <patryk.ludwikowski.7@gmail.com>
 homepage: https://github.com/edufolly/flutter_bluetooth_serial/tree/master/example/
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
 
-  scoped_model: ^2.0.0-nullsafety.0
-  cupertino_icons: ^1.0.3
+  scoped_model: ^2.0.0
+  cupertino_icons: ^1.0.8
 
 dev_dependencies:
   flutter_test:

--- a/ios/flutter_bluetooth_serial.podspec
+++ b/ios/flutter_bluetooth_serial.podspec
@@ -16,6 +16,6 @@ A basic Flutter Bluetooth Serial
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '12.0'
 end
 

--- a/lib/BluetoothConnection.dart
+++ b/lib/BluetoothConnection.dart
@@ -91,7 +91,7 @@ class BluetoothConnection {
 }
 
 /// Helper class for sending responses.
-class _BluetoothStreamSink<Uint8List> extends StreamSink<Uint8List> {
+class _BluetoothStreamSink<Uint8List> implements StreamSink<Uint8List> {
   final int? _id;
 
   /// Describes is stream connected.

--- a/lib/FlutterBluetoothSerial.dart
+++ b/lib/FlutterBluetoothSerial.dart
@@ -272,7 +272,7 @@ class FlutterBluetoothSerial {
   @Deprecated(
       'Use `BluetoothConnection.output` with some decoding (such as `ascii.decode` for strings) instead')
   Future<void> write(String message) {
-    _defaultConnection!.output.add(utf8.encode(message) as Uint8List);
+    _defaultConnection!.output.add(utf8.encode(message));
     return _defaultConnection!.output.allSent;
   }
 

--- a/lib/flutter_bluetooth_serial.dart
+++ b/lib/flutter_bluetooth_serial.dart
@@ -1,7 +1,6 @@
 library flutter_bluetooth_serial;
 
 import 'dart:async';
-import 'dart:typed_data';
 import 'dart:convert';
 
 import 'package:flutter/services.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: flutter_bluetooth_serial
-version: 0.4.0
+version: 1.0.0
 description: Flutter basic implementation for Classical Bluetooth (only RFCOMM for now).
 homepage: https://github.com/edufolly/flutter_bluetooth_serial
 repository: https://github.com/edufolly/flutter_bluetooth_serial
 issue_tracker: https://github.com/edufolly/flutter_bluetooth_serial/issues
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.17.0"
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
  - Upgrade Dart SDK to >=3.0.0 <4.0.0
  - Upgrade Flutter SDK to >=3.13.0
  - Update Android Gradle Plugin to 8.6.0 and Gradle to 8.7
  - Migrate to declarative Gradle plugin syntax
  - Update compile SDK to 36, min SDK to 21, target SDK to 34
  - Add Android 12+ Bluetooth permissions
  - Fix StreamSink interface class compatibility
  - Replace deprecated jcenter with mavenCentral
  - Add namespace configuration for AGP 8+
  - Update all dependencies to latest stable versions
  - Bump package version to 1.0.0

  BREAKING CHANGE: Minimum SDK requirements increased