### PR TITLE
chore: upgrade Dart 3.7, AGP 8.6.1, compileSdk 36, fix Android 14+ permissions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,40 +1,34 @@
-group 'io.github.edufolly.flutterbluetoothserial'
-version '1.0-SNAPSHOT'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.6.1'
+    }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+    namespace 'io.github.edufolly.flutterbluetoothserial'
+    compileSdk 36
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
-    }
-}
-rootProject.allprojects {
-    repositories {
-        google()
-        jcenter()
-    }
-}
-apply plugin: 'com.android.library'
-android {
-    compileSdkVersion 30
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
     defaultConfig {
-        minSdkVersion 19
+        minSdk 21
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-    lintOptions {
+
+    lint {
         disable 'InvalidPackage'
     }
-    dependencies {
-        implementation 'androidx.appcompat:appcompat:1.3.0'
-    }
-    buildToolsVersion '30.0.3'
 }
 
 dependencies {
+    implementation 'androidx.appcompat:appcompat:1.7.0'
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,5 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4096M
 android.enableJetifier=true
 android.useAndroidX=true
+android.nonTransitiveRClass=true
+android.suppressUnsupportedCompileSdk=36

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,9 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+networkTimeout=10000
+retries=0
+retryBackOffMs=500
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 rootProject.name = 'flutter_bluetooth_serial'

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,7 +1,9 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.github.edufolly.flutterbluetoothserial">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 </manifest>

--- a/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
+++ b/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
@@ -413,7 +413,14 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
                 (requestCode, permissions, grantResults) -> {
                     switch (requestCode) {
                         case REQUEST_COARSE_LOCATION_PERMISSIONS:
-                            pendingPermissionsEnsureCallbacks.onResult(grantResults[0] == PackageManager.PERMISSION_GRANTED);
+                            boolean allGranted = true;
+                            for (int result : grantResults) {
+                                if (result != PackageManager.PERMISSION_GRANTED) {
+                                    allGranted = false;
+                                    break;
+                                }
+                            }
+                            pendingPermissionsEnsureCallbacks.onResult(allGranted);
                             pendingPermissionsEnsureCallbacks = null;
                             return true;
                     }
@@ -448,17 +455,30 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
     EnsurePermissionsCallback pendingPermissionsEnsureCallbacks = null;
 
     private void ensurePermissions(EnsurePermissionsCallback callbacks) {
-        if (
-                ContextCompat.checkSelfPermission(activity,
-                        Manifest.permission.ACCESS_COARSE_LOCATION)
-                        != PackageManager.PERMISSION_GRANTED
-                        || ContextCompat.checkSelfPermission(activity,
-                        Manifest.permission.ACCESS_FINE_LOCATION)
-                        != PackageManager.PERMISSION_GRANTED) {
-            ActivityCompat.requestPermissions(activity,
-                    new String[]{Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION},
-                    REQUEST_COARSE_LOCATION_PERMISSIONS);
+        List<String> permissionsNeeded = new ArrayList<>();
+        if (ContextCompat.checkSelfPermission(activity,
+                Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            permissionsNeeded.add(Manifest.permission.ACCESS_COARSE_LOCATION);
+        }
+        if (ContextCompat.checkSelfPermission(activity,
+                Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            permissionsNeeded.add(Manifest.permission.ACCESS_FINE_LOCATION);
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (ContextCompat.checkSelfPermission(activity,
+                    Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
+                permissionsNeeded.add(Manifest.permission.BLUETOOTH_SCAN);
+            }
+            if (ContextCompat.checkSelfPermission(activity,
+                    Manifest.permission.BLUETOOTH_CONNECT) != PackageManager.PERMISSION_GRANTED) {
+                permissionsNeeded.add(Manifest.permission.BLUETOOTH_CONNECT);
+            }
+        }
 
+        if (!permissionsNeeded.isEmpty()) {
+            ActivityCompat.requestPermissions(activity,
+                    permissionsNeeded.toArray(new String[0]),
+                    REQUEST_COARSE_LOCATION_PERMISSIONS);
             pendingPermissionsEnsureCallbacks = callbacks;
         } else {
             callbacks.onResult(true);

--- a/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
+++ b/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
+import android.os.Build;
 
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
@@ -115,7 +116,12 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
             public void onReceive(Context context, Intent intent) {
                 switch (intent.getAction()) {
                     case BluetoothDevice.ACTION_PAIRING_REQUEST:
-                        final BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+                        final BluetoothDevice device;
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice.class);
+                        } else {
+                            device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+                        }
                         final int pairingVariant = intent.getIntExtra(BluetoothDevice.EXTRA_PAIRING_VARIANT, BluetoothDevice.ERROR);
                         Log.d(TAG, "Pairing request (variant " + pairingVariant + ") incoming from " + device.getAddress());
                         switch (pairingVariant) {
@@ -269,7 +275,12 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
                 final String action = intent.getAction();
                 switch (action) {
                     case BluetoothDevice.ACTION_FOUND:
-                        final BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+                        final BluetoothDevice device;
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice.class);
+                        } else {
+                            device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+                        }
                         //final BluetoothClass deviceClass = intent.getParcelableExtra(BluetoothDevice.EXTRA_CLASS); // @TODO . !BluetoothClass!
                         //final String extraName = intent.getStringExtra(BluetoothDevice.EXTRA_NAME); // @TODO ? !EXTRA_NAME!
                         final int deviceRSSI = intent.getShortExtra(BluetoothDevice.EXTRA_RSSI, Short.MIN_VALUE);
@@ -593,7 +604,7 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
 
                 case "requestDisable":
                     if (bluetoothAdapter.isEnabled()) {
-                        bluetoothAdapter.disable();
+                        disableAdapter();
                         result.success(true);
                     } else {
                         result.success(false);
@@ -802,7 +813,12 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
                             switch (intent.getAction()) {
                                 // @TODO . BluetoothDevice.ACTION_PAIRING_CANCEL
                                 case BluetoothDevice.ACTION_BOND_STATE_CHANGED:
-                                    final BluetoothDevice someDevice = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+                                    final BluetoothDevice someDevice;
+                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                        someDevice = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice.class);
+                                    } else {
+                                        someDevice = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+                                    }
                                     if (!someDevice.equals(device)) {
                                         break;
                                     }
@@ -1040,5 +1056,10 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
             }
         }
 
+    }
+
+    @SuppressWarnings("deprecation")
+    private void disableAdapter() {
+        bluetoothAdapter.disable();
     }
 }

--- a/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
+++ b/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
@@ -116,12 +116,7 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
             public void onReceive(Context context, Intent intent) {
                 switch (intent.getAction()) {
                     case BluetoothDevice.ACTION_PAIRING_REQUEST:
-                        final BluetoothDevice device;
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                            device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice.class);
-                        } else {
-                            device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
-                        }
+                        final BluetoothDevice device = getDeviceExtra(intent);
                         final int pairingVariant = intent.getIntExtra(BluetoothDevice.EXTRA_PAIRING_VARIANT, BluetoothDevice.ERROR);
                         Log.d(TAG, "Pairing request (variant " + pairingVariant + ") incoming from " + device.getAddress());
                         switch (pairingVariant) {
@@ -275,12 +270,7 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
                 final String action = intent.getAction();
                 switch (action) {
                     case BluetoothDevice.ACTION_FOUND:
-                        final BluetoothDevice device;
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                            device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice.class);
-                        } else {
-                            device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
-                        }
+                        final BluetoothDevice device = getDeviceExtra(intent);
                         //final BluetoothClass deviceClass = intent.getParcelableExtra(BluetoothDevice.EXTRA_CLASS); // @TODO . !BluetoothClass!
                         //final String extraName = intent.getStringExtra(BluetoothDevice.EXTRA_NAME); // @TODO ? !EXTRA_NAME!
                         final int deviceRSSI = intent.getShortExtra(BluetoothDevice.EXTRA_RSSI, Short.MIN_VALUE);
@@ -813,12 +803,7 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
                             switch (intent.getAction()) {
                                 // @TODO . BluetoothDevice.ACTION_PAIRING_CANCEL
                                 case BluetoothDevice.ACTION_BOND_STATE_CHANGED:
-                                    final BluetoothDevice someDevice;
-                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                                        someDevice = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice.class);
-                                    } else {
-                                        someDevice = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
-                                    }
+                                    final BluetoothDevice someDevice = getDeviceExtra(intent);
                                     if (!someDevice.equals(device)) {
                                         break;
                                     }
@@ -1061,5 +1046,14 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
     @SuppressWarnings("deprecation")
     private void disableAdapter() {
         bluetoothAdapter.disable();
+    }
+
+    @SuppressWarnings("deprecation")
+    private BluetoothDevice getDeviceExtra(Intent intent) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice.class);
+        } else {
+            return intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+        }
     }
 }

--- a/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
+++ b/android/src/main/java/io/github/edufolly/flutterbluetoothserial/FlutterBluetoothSerialPlugin.java
@@ -18,7 +18,8 @@ import androidx.core.content.ContextCompat;
 
 import android.util.Log;
 import android.util.SparseArray;
-import android.os.AsyncTask;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -74,6 +75,7 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
 
     /// Last ID given to any connection, used to avoid duplicate IDs 
     private int lastConnectionId = 0;
+    private final ExecutorService executorService = Executors.newCachedThreadPool();
     private Activity activity;
     private BinaryMessenger messenger;
     private Context activeContext;
@@ -375,6 +377,7 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
     @Override
     public void onDetachedFromEngine(@NonNull FlutterPlugin.FlutterPluginBinding binding) {
         if (methodChannel != null) methodChannel.setMethodCallHandler(null);
+        executorService.shutdown();
     }
 
     @Override
@@ -511,7 +514,7 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
                     self.disconnect();
 
                     // True dispose
-                    AsyncTask.execute(() -> {
+                    executorService.execute(() -> {
                         readChannel.setStreamHandler(null);
                         connections.remove(id);
 
@@ -625,35 +628,6 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
                                 // Ignoring failure (since it isn't critical API for most applications)
                                 Log.d(TAG, "Obtaining address using Settings Secure bank failed");
                                 //result.error("hidden_address", "obtaining address using Settings Secure bank failed", exceptionToString(ex));
-                            }
-
-                            Log.d(TAG, "Trying to obtain address using reflection against internal Android code");
-                            try {
-                                // This will most likely work, but well, it is unsafe
-                                java.lang.reflect.Field mServiceField;
-                                mServiceField = bluetoothAdapter.getClass().getDeclaredField("mService");
-                                mServiceField.setAccessible(true);
-
-                                Object bluetoothManagerService = mServiceField.get(bluetoothAdapter);
-                                if (bluetoothManagerService == null) {
-                                    if (!bluetoothAdapter.isEnabled()) {
-                                        Log.d(TAG, "Probably failed just because adapter is disabled!");
-                                    }
-                                    throw new NullPointerException();
-                                }
-                                java.lang.reflect.Method getAddressMethod;
-                                getAddressMethod = bluetoothManagerService.getClass().getMethod("getAddress");
-                                String value = (String) getAddressMethod.invoke(bluetoothManagerService);
-                                if (value == null) {
-                                    throw new NullPointerException();
-                                }
-                                address = value;
-                                Log.d(TAG, "Probably succed: " + address + " ✨ :F");
-                                break;
-                            } catch (Exception ex) {
-                                // Ignoring failure (since it isn't critical API for most applications)
-                                Log.d(TAG, "Obtaining address using reflection against internal Android code failed");
-                                //result.error("hidden_address", "obtaining address using reflection agains internal Android code failed", exceptionToString(ex));
                             }
 
                             Log.d(TAG, "Trying to look up address by network interfaces - might be invalid on some devices");
@@ -1002,7 +976,7 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
 
                     Log.d(TAG, "Connecting to " + address + " (id: " + id + ")");
 
-                    AsyncTask.execute(() -> {
+                    executorService.execute(() -> {
                         try {
                             connection.connect(address);
                             activity.runOnUiThread(() -> result.success(id));
@@ -1036,7 +1010,7 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
 
                     if (call.hasArgument("string")) {
                         String string = call.argument("string");
-                        AsyncTask.execute(() -> {
+                        executorService.execute(() -> {
                             try {
                                 connection.write(string.getBytes());
                                 activity.runOnUiThread(() -> result.success(null));
@@ -1046,7 +1020,7 @@ public class FlutterBluetoothSerialPlugin implements FlutterPlugin, ActivityAwar
                         });
                     } else if (call.hasArgument("bytes")) {
                         byte[] bytes = call.argument("bytes");
-                        AsyncTask.execute(() -> {
+                        executorService.execute(() -> {
                             try {
                                 connection.write(bytes);
                                 activity.runOnUiThread(() -> result.success(null));

--- a/docs/upgrade-plan.md
+++ b/docs/upgrade-plan.md
@@ -1,0 +1,90 @@
+# Flutter Bluetooth Serial 升级方案
+
+## 目标
+
+- Dart SDK >= 3.7, Flutter >= 3.28
+- Android: compileSdk 36, targetSdk 36, minSdk 21, AGP 8.6.1, Gradle 8.7, JDK 17
+- 支持 Android 12+ 新蓝牙权限模型（同时保留旧权限兼容 Android 11-）
+
+## 当前状态 vs 实际目标
+
+### Dart / Flutter
+
+| 项目 | 当前 | 目标 |
+|------|------|------|
+| SDK 约束 | `>=2.12.0 <3.0.0` | `>=3.7.0 <4.0.0` |
+| Flutter 约束 | `>=1.17.0` | `>=3.28.0` |
+
+### Android 构建（插件）
+
+| 项目 | 当前 | 目标 |
+|------|------|------|
+| AGP | 4.1.0 | 8.6.1 |
+| Gradle | 6.7 | 8.7 |
+| compileSdk | 30 | 36 |
+| minSdk | 19 | 21 |
+| targetSdk | 30 | 36 |
+| JDK | 8/11 | 17 |
+| source/targetCompatibility | Java 8 | Java 17 |
+| appcompat | 1.3.0 | 1.7.0 |
+| 仓库 | google() + jcenter() | google() + mavenCentral() |
+| buildToolsVersion | 30.0.3 | 删除（AGP 自动管理） |
+| group/version 声明 | 存在 | 删除 |
+| rootProject.allprojects | 存在 | 删除 |
+| lintOptions | `disable 'InvalidPackage'` | `lint { disable 'InvalidPackage' }` |
+| 命名空间 | manifest package 属性 | build.gradle namespace 块 |
+
+### Android 构建（Example App）
+
+与插件构建配置同步升级，额外改动：
+
+- `app/build.gradle` 改用声明式 `plugins {}` 块（Flutter 3.38 要求）
+- `AndroidManifest.xml` 添加 `android:exported="true"`（Android 12+ 要求）
+- 移除 `AndroidManifest.xml` 的 `package` 属性（改用 namespace）
+- 添加 `ndkVersion "28.2.13676358"`（integration_test 要求）
+- JVM heap 从 1536M 提升到 4096M
+
+### AndroidManifest 权限
+
+```xml
+<!-- 新增 Android 12+ 权限 -->
+<uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+    android:usesPermissionFlags="neverForLocation" />
+<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
+<!-- 旧权限不变 -->
+<uses-permission android:name="android.permission.BLUETOOTH" />
+<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+```
+
+### Java 代码改动
+
+1. **AsyncTask → ExecutorService**（4 处）
+   - 使用 `Executors.newCachedThreadPool()` 替代
+   - `connect`、`write`（string/bytes）、`onCancel` 中的清理逻辑
+   - `onDetachedFromEngine` 中调用 `executorService.shutdown()` 清理线程
+
+2. **getAddress mService 反射删除**
+   - 移除通过反射访问 `BluetoothAdapter.mService` 获取地址的代码
+   - 保留 `Settings.Secure` 和 `NetworkInterface` 作为兜底方案
+
+3. **isConnected / removeBond 反射** — 已有 try-catch，无需额外修改
+
+### Dart 代码改动
+
+- `BluetoothConnection.dart`: `StreamSink` 从 `extends` 改为 `implements`（Dart 3.x interface class）
+- `FlutterBluetoothSerial.dart`: 移除不必要的 `as Uint8List` 强制转换
+- `BluetoothConnection.dart`: 移除未使用的 `_id` 字段
+- `flutter_bluetooth_serial.dart`: 移除不必要的 `dart:typed_data` import
+
+### Example App 修复
+
+- `LineChart.dart`: `TextTheme.caption` → `TextTheme.bodySmall`（Flutter 3.x 已移除）
+
+## 验证结果
+
+- `flutter pub get` — 通过
+- `flutter analyze` — 0 error，0 warning（插件代码）；4 warning（example 预存）
+- `flutter build apk --debug` — 通过，生成 `app-debug.apk`

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -55,6 +55,7 @@
 **/ios/.generated/
 **/ios/Flutter/App.framework
 **/ios/Flutter/Flutter.framework
+**/ios/Flutter/ephemeral/
 **/ios/Flutter/Generated.xcconfig
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,49 +1,37 @@
-def localProperties = new Properties()
-def localPropertiesFile = rootProject.file('local.properties')
-if (localPropertiesFile.exists()) {
-    localPropertiesFile.withReader('UTF-8') { reader ->
-        localProperties.load(reader)
-    }
+plugins {
+    id "com.android.application"
+    id "dev.flutter.flutter-gradle-plugin"
 }
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
-}
-
-apply plugin: 'com.android.application'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
-    lintOptions {
+    namespace "io.github.edufolly.flutterbluetoothserialexample"
+    compileSdk 36
+
+    lint {
         disable 'InvalidPackage'
     }
+
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.github.edufolly.flutterbluetoothserialexample"
-        minSdkVersion 19
-        targetSdkVersion 30
+        minSdk flutter.minSdkVersion
+        targetSdk 36
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
     }
-    buildToolsVersion '30.0.3'
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-}
 
-flutter {
-    source '../..'
+    ndkVersion "28.2.13676358"
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
 }
 
 dependencies {

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.github.edufolly.flutterbluetoothserialexample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application
@@ -17,6 +16,7 @@
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name="io.flutter.embedding.android.FlutterActivity"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,21 +1,3 @@
-buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        jcenter()
-    }
-}
-
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
@@ -24,6 +6,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register("clean", Delete) {
+    delete rootProject.layout.buildDirectory
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,5 @@
 android.enableJetifier=true
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx1536M
+android.nonTransitiveRClass=true
+android.suppressUnsupportedCompileSdk=36
+org.gradle.jvmargs=-Xmx4096M

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Mon Mar 18 21:10:34 BRT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,3 +1,26 @@
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
+
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.6.1" apply false
+}
+
 include ':app'
 
 def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()

--- a/example/lib/SelectBondedDevicePage.dart
+++ b/example/lib/SelectBondedDevicePage.dart
@@ -17,7 +17,6 @@ class SelectBondedDevicePage extends StatefulWidget {
 }
 
 enum _DeviceAvailability {
-  no,
   maybe,
   yes,
 }
@@ -27,7 +26,7 @@ class _DeviceWithAvailability {
   _DeviceAvailability availability;
   int? rssi;
 
-  _DeviceWithAvailability(this.device, this.availability, [this.rssi]);
+  _DeviceWithAvailability(this.device, this.availability);
 }
 
 class _SelectBondedDevicePage extends State<SelectBondedDevicePage> {

--- a/example/lib/helpers/LineChart.dart
+++ b/example/lib/helpers/LineChart.dart
@@ -162,9 +162,9 @@ class LineChart extends StatelessWidget {
           values: values,
           valuesLabels: valuesLabels,
           horizontalLabelsTextStyle:
-              horizontalLabelsTextStyle ?? Theme.of(context).textTheme.caption,
+              horizontalLabelsTextStyle ?? Theme.of(context).textTheme.bodySmall,
           verticalLabelsTextStyle:
-              verticalLabelsTextStyle ?? Theme.of(context).textTheme.caption,
+              verticalLabelsTextStyle ?? Theme.of(context).textTheme.bodySmall,
           horizontalLinesPaint: horizontalLinesPaint,
           verticalLinesPaint: verticalLinesPaint,
           additionalMinimalHorizontalLabelsInterval:
@@ -510,7 +510,8 @@ class _LineChartPainter extends CustomPainter {
       Iterator<double> argument = arguments.iterator;
       while (value.moveNext()) {
         argument.moveNext();
-        if (value.current == null || value.current == double.nan) continue;
+        final current = value.current;
+        if (current == null || current.isNaN) continue;
 
         if (argument.current < argumentsOffset) continue;
         final double xOffset = padding.left +

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,8 +1,6 @@
 name: flutter_bluetooth_serial_example
 version: 0.4.0
 description: Demonstrates how to use the `flutter_bluetooth_serial` plugin.
-authors:
-  - Patryk Ludwikowski <patryk.ludwikowski.7@gmail.com>
 homepage: https://github.com/edufolly/flutter_bluetooth_serial/tree/master/example/
 
 environment:

--- a/lib/BluetoothConnection.dart
+++ b/lib/BluetoothConnection.dart
@@ -16,9 +16,6 @@ class BluetoothConnection {
   //    listen to `input` even just for the `onDone` to proper detect closing.
   //
 
-  /// This ID identifies real full `BluetoothConenction` object on platform side code.
-  final int? _id;
-
   final EventChannel _readChannel;
   late StreamSubscription<Uint8List> _readStreamSubscription;
   late StreamController<Uint8List> _readStreamController;
@@ -39,8 +36,7 @@ class BluetoothConnection {
   bool get isConnected => output.isConnected;
 
   BluetoothConnection._consumeConnectionID(int? id)
-      : this._id = id,
-        this._readChannel =
+      : this._readChannel =
             EventChannel('${FlutterBluetoothSerial.namespace}/read/$id') {
     _readStreamController = StreamController<Uint8List>();
 
@@ -91,7 +87,7 @@ class BluetoothConnection {
 }
 
 /// Helper class for sending responses.
-class _BluetoothStreamSink<Uint8List> extends StreamSink<Uint8List> {
+class _BluetoothStreamSink<Uint8List> implements StreamSink<Uint8List> {
   final int? _id;
 
   /// Describes is stream connected.

--- a/lib/FlutterBluetoothSerial.dart
+++ b/lib/FlutterBluetoothSerial.dart
@@ -272,7 +272,7 @@ class FlutterBluetoothSerial {
   @Deprecated(
       'Use `BluetoothConnection.output` with some decoding (such as `ascii.decode` for strings) instead')
   Future<void> write(String message) {
-    _defaultConnection!.output.add(utf8.encode(message) as Uint8List);
+    _defaultConnection!.output.add(utf8.encode(message));
     return _defaultConnection!.output.allSent;
   }
 

--- a/lib/flutter_bluetooth_serial.dart
+++ b/lib/flutter_bluetooth_serial.dart
@@ -1,7 +1,6 @@
 library flutter_bluetooth_serial;
 
 import 'dart:async';
-import 'dart:typed_data';
 import 'dart:convert';
 
 import 'package:flutter/services.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/edufolly/flutter_bluetooth_serial
 issue_tracker: https://github.com/edufolly/flutter_bluetooth_serial/issues
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.17.0"
+  sdk: '>=3.7.0 <4.0.0'
+  flutter: ">=3.28.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
- Upgrade Dart SDK >=3.7, Flutter >=3.28, Android AGP 8.6.1, compileSdk/targetSdk 36                                                                        
- Resolve Java deprecation warnings for API 33+                                                                                                             
- Add BLUETOOTH_SCAN and BLUETOOTH_CONNECT runtime permission requests for Android 14+                                                                      
- Fix onRequestPermissionsResult to check all grant results    